### PR TITLE
fix: fix broken link in readme.md

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -4,12 +4,12 @@ BNB Studio 是一个帮助开发者快速开发 BNB 智能合约的集成化开�
 
 ![](./screenshots/main.png)
 
-[English](https://github.com/ObsidianLabs/BNB-Studio/blob/master/README.md) | 简体中文
+[English](./README.md) | 简体中文
 ## 安装
 
 ### 下载
 
-BNB Studio 安装包可以在 [Github Releases](https://github.com/ObsidianLabs/BNB-Studio/releases) 进行下载。目前 BNB Studio 支持 macOS, Linux 和 Windows 系统，请根据系统下载对应的版本 (macOS 下载 .dmg 或者 .zip，Linux 下载 .AppImage, Windows 下载 .exe)。
+BNB Studio 安装包可以在 [Github Releases](https://github.com/ObsidianLabs/BSC-Studio/releases) 进行下载。目前 BNB Studio 支持 macOS, Linux 和 Windows 系统，请根据系统下载对应的版本 (macOS 下载 .dmg 或者 .zip，Linux 下载 .AppImage, Windows 下载 .exe)。
 
 ### 安装
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -9,7 +9,7 @@ BNB Studio 是一个帮助开发者快速开发 BNB 智能合约的集成化开�
 
 ### 下载
 
-BNB Studio 安装包可以在 [Github Releases](https://github.com/ObsidianLabs/BSC-Studio/releases) 进行下载。目前 BNB Studio 支持 macOS, Linux 和 Windows 系统，请根据系统下载对应的版本 (macOS 下载 .dmg 或者 .zip，Linux 下载 .AppImage, Windows 下载 .exe)。
+BNB Studio 安装包可以在 [Github Releases](https://github.com/ObsidianLabs/BNB-Studio/releases) 进行下载。目前 BNB Studio 支持 macOS, Linux 和 Windows 系统，请根据系统下载对应的版本 (macOS 下载 .dmg 或者 .zip，Linux 下载 .AppImage, Windows 下载 .exe)。
 
 ### 安装
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ BNB Studio is an integrated development environment (IDE), making developing BNB
 
 ![](./screenshots/compile.png)
 
-English | [简体中文](https://github.com/ObsidianLabs/BNB-Studio/blob/master/README-CN.md)
+English | [简体中文](./README-CN.md)
 
 ## Installation
 
 ### Download
 
-Download BNB Studio install-package in [Github Release](https://github.com/ObsidianLabs/BNB-Studio/releases) according to the computer system type (.dmg/.zip for macOS, .AppImage for Linux, .exe for Windows).
+Download BNB Studio install-package in [Github Release](https://github.com/ObsidianLabs/BSC-Studio/releases) according to the computer system type (.dmg/.zip for macOS, .AppImage for Linux, .exe for Windows).
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ English | [简体中文](./README-CN.md)
 
 ### Download
 
-Download BNB Studio install-package in [Github Release](https://github.com/ObsidianLabs/BSC-Studio/releases) according to the computer system type (.dmg/.zip for macOS, .AppImage for Linux, .exe for Windows).
+Download BNB Studio install-package in [Github Release](https://github.com/ObsidianLabs/BNB-Studio/releases) according to the computer system type (.dmg/.zip for macOS, .AppImage for Linux, .exe for Windows).
 
 ### Install
 


### PR DESCRIPTION
from absolutely link `https://github.com/ObsidianLabs/BNB-Studio/blob/master/readme.md` to releatively linke `./readme.md`