### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ English | [简体中文](https://github.com/ObsidianLabs/BNB-Studio/blob/master/
 
 ### Download
 
-Download BNB Studio install-package in [Github Release](https://github.com/ObsidianLabs/BNB-Studio/releases) according to the computer system type (.dmg/.zip for macOS, .AppImage for Linux, .exe for Windows).
+Download BNB Studio install-package in [Github Release](https://github.com/ObsidianLabs/BSC-Studio/releases) according to the computer system type (.dmg/.zip for macOS, .AppImage for Linux, .exe for Windows).
 
 ### Install
 


### PR DESCRIPTION
README link to downloads was pointed at BNB-Studio/Releases, this PR corrects it to BSC-Studio/Releases